### PR TITLE
define interface that has only the bare minimum required

### DIFF
--- a/Patch.py
+++ b/Patch.py
@@ -8,7 +8,7 @@ if __name__ == "__main__":
     import ModuleUpdate
     ModuleUpdate.update()
 
-from worlds.Files import AutoPatchRegister, APProcedurePatch
+from worlds.Files import AutoPatchRegister, APPatch
 
 
 class RomMeta(TypedDict):
@@ -20,7 +20,7 @@ class RomMeta(TypedDict):
 def create_rom_file(patch_file: str) -> Tuple[RomMeta, str]:
     auto_handler = AutoPatchRegister.get_handler(patch_file)
     if auto_handler:
-        handler: APProcedurePatch = auto_handler(patch_file)
+        handler: APPatch = auto_handler(patch_file)
         target = os.path.splitext(patch_file)[0]+handler.result_file_ending
         handler.patch(target)
         return {"server": handler.server,

--- a/worlds/Files.py
+++ b/worlds/Files.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import abc
 import json
 import struct
 import zipfile
@@ -17,7 +18,7 @@ del threading
 del os
 
 
-class AutoPatchRegister(type):
+class AutoPatchRegister(abc.ABCMeta):
     patch_types: ClassVar[Dict[str, AutoPatchRegister]] = {}
     file_endings: ClassVar[Dict[str, AutoPatchRegister]] = {}
 
@@ -142,15 +143,26 @@ class APContainer:
         }
 
 
-class APProcedurePatch(APContainer, metaclass=AutoPatchRegister):
+class APPatch(APContainer, abc.ABC, metaclass=AutoPatchRegister):
     """
-    An APContainer that defines a procedure to produce the desired file.
+    An abstract `APContainer` that defines the requirements for an object
+    to be used by the `Patch.create_rom_file` function.
+    """
+    result_file_ending: str = ".sfc"
+
+    @abc.abstractmethod
+    def patch(self, target: str) -> None:
+        """ create the output file with the file name `target` """
+
+
+class APProcedurePatch(APPatch):
+    """
+    An APPatch that defines a procedure to produce the desired file.
     """
     procedure: List[Tuple[str, List[Any]]]
     hash: Optional[str]  # base checksum of source file
     source_data: bytes
     patch_file_ending: str = ""
-    result_file_ending: str = ".sfc"
     files: Dict[str, bytes] = {}
 
     @classmethod


### PR DESCRIPTION
## What is this fixing or adding?

Following principles of object oriented programming, there should be an interface that has only the bare minimum required for what is needed where the object is used.

We can see in the `create_rom_file` function that, in addition to members from `APContainer`, the patch only needs to have a `result_file_ending`, and a `patch` method.

This interface would give a path for other implementations that don't need or want everything offered by `APProcedurePatch`

## How was this tested?

unit tests