### PR TITLE
testing for definitions of `patch_suffix`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ certifi>=2023.11.17
 cython>=3.0.8
 cymem>=2.0.8
 orjson>=3.9.10
+typing-extensions>=4.7

--- a/worlds/AutoSNIClient.py
+++ b/worlds/AutoSNIClient.py
@@ -1,7 +1,9 @@
 
 from __future__ import annotations
 import abc
-from typing import TYPE_CHECKING, ClassVar, Dict, Tuple, Any, Optional, Union
+from typing import TYPE_CHECKING, ClassVar, Dict, Iterable, Tuple, Any, Optional, Union
+
+from typing_extensions import TypeGuard
 
 from worlds.LauncherComponents import Component, SuffixIdentifier, Type, components
 
@@ -10,6 +12,23 @@ if TYPE_CHECKING:
 
 component = Component('SNI Client', 'SNIClient', component_type=Type.CLIENT, file_identifier=SuffixIdentifier(".apsoe"))
 components.append(component)
+
+
+def valid_patch_suffix(obj: object) -> TypeGuard[Union[str, Iterable[str]]]:
+    """ make sure this is a valid value for the class variable `patch_suffix` """
+
+    def valid_individual(one: object) -> TypeGuard[str]:
+        """ check an individual suffix """
+        # TODO: decide:                 len(one) > 3 and one.startswith(".ap") ?
+        # or keep it more general?
+        return isinstance(one, str) and len(one) > 1 and one.startswith(".")
+
+    if isinstance(obj, str):
+        return valid_individual(obj)
+    if not isinstance(obj, Iterable):
+        return False
+    obj_it: Iterable[object] = obj
+    return all(valid_individual(each) for each in obj_it)
 
 
 class AutoSNIClientRegister(abc.ABCMeta):
@@ -22,16 +41,19 @@ class AutoSNIClientRegister(abc.ABCMeta):
             AutoSNIClientRegister.game_handlers[dct["game"]] = new_class()
 
         if "patch_suffix" in dct:
-            if dct["patch_suffix"] is not None:
-                existing_identifier: SuffixIdentifier = component.file_identifier
-                new_suffixes = [*existing_identifier.suffixes]
+            patch_suffix = dct["patch_suffix"]
+            assert valid_patch_suffix(patch_suffix), f"class {name} defining invalid {patch_suffix=}"
 
-                if type(dct["patch_suffix"]) is str:
-                    new_suffixes.append(dct["patch_suffix"])
-                else:
-                    new_suffixes.extend(dct["patch_suffix"])
+            existing_identifier = component.file_identifier
+            assert isinstance(existing_identifier, SuffixIdentifier), f"{existing_identifier=}"
+            new_suffixes = [*existing_identifier.suffixes]
 
-                component.file_identifier = SuffixIdentifier(*new_suffixes)
+            if isinstance(patch_suffix, str):
+                new_suffixes.append(patch_suffix)
+            else:
+                new_suffixes.extend(patch_suffix)
+
+            component.file_identifier = SuffixIdentifier(*new_suffixes)
 
         return new_class
 
@@ -45,7 +67,7 @@ class AutoSNIClientRegister(abc.ABCMeta):
 
 class SNIClient(abc.ABC, metaclass=AutoSNIClientRegister):
 
-    patch_suffix: ClassVar[Optional[Union[str, Tuple[str, ...]]]]
+    patch_suffix: ClassVar[Union[str, Iterable[str]]] = ()
     """The file extension(s) this client is meant to open and patch (e.g. ".aplttp")"""
 
     @abc.abstractmethod


### PR DESCRIPTION
## What is this fixing or adding?

unit tests will be able to see if `patch_suffix` is invalid

This also addresses some of the other things I commented on in that pull request.

Note that `typing-extensions` isn't a new dependency. It's already a dependency of other packages we depend on. It's just better to be explicit if we use it directly (in case we remove the other dependencies that depend on it).

## How was this tested?

change lttp to `patch_suffix = 3` to make sure it would fail the unit test