### PR TITLE
Various Small Fixes

### DIFF
--- a/worlds/rogue_legacy/Options.py
+++ b/worlds/rogue_legacy/Options.py
@@ -1,6 +1,4 @@
-from typing import Dict
-
-from Options import Choice, Range, Option, Toggle, DeathLink, DefaultOnToggle, OptionSet, PerGameCommonOptions
+from Options import Choice, Range, Toggle, DeathLink, DefaultOnToggle, OptionSet, PerGameCommonOptions
 
 from dataclasses import dataclass
 
@@ -338,7 +336,9 @@ class AvailableClasses(OptionSet):
     The upgraded form of your starting class will be available regardless.
     """
     display_name = "Available Classes"
-    default = {"Knight", "Mage", "Barbarian", "Knave", "Shinobi", "Miner", "Spellthief", "Lich", "Dragon", "Traitor"}
+    default = frozenset(
+        {"Knight", "Mage", "Barbarian", "Knave", "Shinobi", "Miner", "Spellthief", "Lich", "Dragon", "Traitor"}
+    )
     valid_keys = {"Knight", "Mage", "Barbarian", "Knave", "Shinobi", "Miner", "Spellthief", "Lich", "Dragon", "Traitor"}
 
 
@@ -377,4 +377,3 @@ class RLOptions(PerGameCommonOptions):
     additional_lady_names: AdditionalNames
     additional_sir_names: AdditionalNames
     death_link: DeathLink
-

--- a/worlds/rogue_legacy/Regions.py
+++ b/worlds/rogue_legacy/Regions.py
@@ -12,7 +12,7 @@ class RLRegionData(NamedTuple):
     region_exits: Optional[List[str]]
 
 
-def create_regions(world: "RLWorld", player: int):
+def create_regions(world: "RLWorld"):
     regions: Dict[str, RLRegionData] = {
         "Menu":              RLRegionData(None, ["Castle Hamson"]),
         "The Manor":         RLRegionData([],   []),
@@ -59,7 +59,7 @@ def create_regions(world: "RLWorld", player: int):
     regions["The Fountain Room"].locations.append("Fountain Room")
 
     # Chests
-    chests = int(world.options.chests_per_zone.value)
+    chests = int(world.options.chests_per_zone)
     for i in range(0, chests):
         if world.options.universal_chests:
             regions["Castle Hamson"].locations.append(f"Chest {i + 1}")
@@ -73,7 +73,7 @@ def create_regions(world: "RLWorld", player: int):
             regions["Land of Darkness"].locations.append(f"Land of Darkness - Chest {i + 1}")
 
     # Fairy Chests
-    chests = int(world.options.fairy_chests_per_zone.value)
+    chests = int(world.options.fairy_chests_per_zone)
     for i in range(0, chests):
         if world.options.universal_fairy_chests:
             regions["Castle Hamson"].locations.append(f"Fairy Chest {i + 1}")
@@ -88,7 +88,7 @@ def create_regions(world: "RLWorld", player: int):
 
     # Set up the regions correctly.
     for name, data in regions.items():
-        world.multiworld.regions.append(create_region(world.multiworld, player, name, data))
+        world.multiworld.regions.append(create_region(world.multiworld, world.player, name, data))
 
     world.get_entrance("Castle Hamson").connect(world.get_region("Castle Hamson"))
     world.get_entrance("The Manor").connect(world.get_region("The Manor"))

--- a/worlds/rogue_legacy/Rules.py
+++ b/worlds/rogue_legacy/Rules.py
@@ -1,13 +1,13 @@
-from BaseClasses import CollectionState, MultiWorld
+from BaseClasses import CollectionState
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from . import RLWorld
 
 
-def get_upgrade_total(multiworld: MultiWorld, player: int) -> int:
-    return int(multiworld.worlds[player].options.health_pool) + int(multiworld.worlds[player].options.mana_pool) + \
-           int(multiworld.worlds[player].options.attack_pool) + int(multiworld.worlds[player].options.magic_damage_pool)
+def get_upgrade_total(world: "RLWorld") -> int:
+    return int(world.options.health_pool) + int(world.options.mana_pool) + \
+           int(world.options.attack_pool) + int(world.options.magic_damage_pool)
 
 
 def get_upgrade_count(state: CollectionState, player: int) -> int:
@@ -23,8 +23,8 @@ def has_upgrade_amount(state: CollectionState, player: int, amount: int) -> bool
     return get_upgrade_count(state, player) >= amount
 
 
-def has_upgrades_percentage(state: CollectionState, player: int, percentage: float) -> bool:
-    return has_upgrade_amount(state, player, round(get_upgrade_total(state.multiworld, player) * (percentage / 100)))
+def has_upgrades_percentage(state: CollectionState, world: "RLWorld", percentage: float) -> bool:
+    return has_upgrade_amount(state, world.player, round(get_upgrade_total(world) * (percentage / 100)))
 
 
 def has_movement_rune(state: CollectionState, player: int) -> bool:
@@ -102,16 +102,16 @@ def set_rules(world: "RLWorld", player: int):
 
     # Region rules.
     world.get_entrance("Forest Abkhazia").access_rule = \
-        lambda state: has_upgrades_percentage(state, player, 12.5) and has_defeated_castle(state, player)
+        lambda state: has_upgrades_percentage(state, world, 12.5) and has_defeated_castle(state, player)
 
     world.get_entrance("The Maya").access_rule = \
-        lambda state: has_upgrades_percentage(state, player, 25) and has_defeated_forest(state, player)
+        lambda state: has_upgrades_percentage(state, world, 25) and has_defeated_forest(state, player)
 
     world.get_entrance("Land of Darkness").access_rule = \
-        lambda state: has_upgrades_percentage(state, player, 37.5) and has_defeated_tower(state, player)
+        lambda state: has_upgrades_percentage(state, world, 37.5) and has_defeated_tower(state, player)
 
     world.get_entrance("The Fountain Room").access_rule = \
-        lambda state: has_upgrades_percentage(state, player, 50) and has_defeated_dungeon(state, player)
+        lambda state: has_upgrades_percentage(state, world, 50) and has_defeated_dungeon(state, player)
 
     # Win condition.
     world.multiworld.completion_condition[player] = lambda state: state.has("Defeat The Fountain", player)

--- a/worlds/rogue_legacy/__init__.py
+++ b/worlds/rogue_legacy/__init__.py
@@ -39,8 +39,8 @@ class RLWorld(World):
     required_client_version = (0, 3, 5)
     web = RLWeb()
 
-    item_name_to_id = {name: data.code for name, data in item_table.items()}
-    location_name_to_id = {name: data.code for name, data in location_table.items()}
+    item_name_to_id = {name: data.code for name, data in item_table.items() if data.code is not None}
+    location_name_to_id = {name: data.code for name, data in location_table.items() if data.code is not None}
 
     def fill_slot_data(self) -> dict:
         return self.options.as_dict(*[name for name in self.options_dataclass.type_hints.keys()])
@@ -157,21 +157,21 @@ class RLWorld(World):
 
             # Skills
             if name == "Health Up":
-                quantity = self.options.health_pool
+                quantity = self.options.health_pool.value
             elif name == "Mana Up":
-                quantity = self.options.mana_pool
+                quantity = self.options.mana_pool.value
             elif name == "Attack Up":
-                quantity = self.options.attack_pool
+                quantity = self.options.attack_pool.value
             elif name == "Magic Damage Up":
-                quantity = self.options.magic_damage_pool
+                quantity = self.options.magic_damage_pool.value
             elif name == "Armor Up":
-                quantity = self.options.armor_pool
+                quantity = self.options.armor_pool.value
             elif name == "Equip Up":
-                quantity = self.options.equip_pool
+                quantity = self.options.equip_pool.value
             elif name == "Crit Chance Up":
-                quantity = self.options.crit_chance_pool
+                quantity = self.options.crit_chance_pool.value
             elif name == "Crit Damage Up":
-                quantity = self.options.crit_damage_pool
+                quantity = self.options.crit_damage_pool.value
 
             # Ignore filler, it will be added in a later stage.
             if data.category == "Filler":
@@ -202,7 +202,7 @@ class RLWorld(World):
         set_rules(self, self.player)
 
     def create_regions(self):
-        create_regions(self, self.player)
+        create_regions(self)
         self._place_events()
 
     def _place_events(self):

--- a/worlds/rogue_legacy/__init__.py
+++ b/worlds/rogue_legacy/__init__.py
@@ -188,7 +188,7 @@ class RLWorld(World):
     def get_filler_item_name(self) -> str:
         fillers = get_items_by_category("Filler")
         weights = [data.weight for data in fillers.values()]
-        return self.multiworld.random.choices([filler for filler in fillers.keys()], weights, k=1)[0]
+        return self.random.choices([filler for filler in fillers.keys()], weights, k=1)[0]
 
     def create_item(self, name: str) -> RLItem:
         data = item_table[name]


### PR DESCRIPTION
## What is this fixing or adding?

Removing unused imports, and excess newlines
Fixing typing for OptionSet default value
Getting `player` from world in `create_regions`
Adding/Removing `.value` where needed/possible
Using `world` instead of `multiworld` and `player` in `get_upgrade_total`
Using `world` instead of `player` in `has_upgrades_percentage` (I'm least certain about this change)
Removing events from the `name_to_id` dicts.
Using `world.random` instead of `multiworld.random`

## How was this tested?

Unit tests, large, fully random generations, comparing generations before the changes and reading through some playthroughs to see that item requirements were still respected.
