### PR TITLE
Plando Items Review

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -841,15 +841,13 @@ def distribute_planned(multiworld: MultiWorld) -> None:
 
     world_name_lookup = multiworld.world_name_lookup
 
-    block_value = typing.Union[typing.List[str], typing.Dict[str, typing.Any]]
     plando_blocks: typing.List[typing.Dict[str, typing.Any]] = []
     player_ids = set(multiworld.player_ids)
     for player in player_ids:
         for block in multiworld.worlds[player].options.plando_items:
             new_block: typing.Dict[str, typing.Any] = {"player": player}
             if not isinstance(block.from_pool, bool):
-                from_pool_type = type(block.from_pool)
-                raise Exception(f"Plando 'from_pool' has to be boolean, not {from_pool_type} for player {player}.")
+                raise Exception(f"Plando 'from_pool' has to be boolean, not {type(block.from_pool)} for player {player}.")
             new_block["from_pool"] = block.from_pool
             new_block["force"] = block.force
             target_world = block.world
@@ -886,7 +884,7 @@ def distribute_planned(multiworld: MultiWorld) -> None:
                 worlds = {world_name_lookup[target_world]}
             new_block["world"] = worlds
 
-            items: block_value = block.items
+            items: typing.Union[typing.List[str], typing.Dict[str, typing.Any]] = block.items
             if isinstance(items, dict):
                 item_list: typing.List[str] = []
                 for key, value in items.items():

--- a/Fill.py
+++ b/Fill.py
@@ -902,8 +902,7 @@ def distribute_planned(multiworld: MultiWorld) -> None:
             if isinstance(locations, str):
                 locations = [locations]
             elif not isinstance(locations, list):
-                locations_type = type(locations)
-                raise Exception(f"Plando 'locations' has to be a list, not {locations_type} for player {player}.")
+                raise Exception(f"Plando 'locations' has to be a list, not {type(locations)} for player {player}.")
 
             locations_from_groups: typing.List[str] = []
             for target_player in worlds:

--- a/Generate.py
+++ b/Generate.py
@@ -291,12 +291,6 @@ def handle_name(name: str, player: int, name_counter: Counter):
     return new_name
 
 
-def roll_percentage(percentage: Union[int, float]) -> bool:
-    """Roll a percentage chance.
-    percentage is expected to be in range [0, 100]"""
-    return random.random() < (float(percentage) / 100)
-
-
 def update_weights(weights: dict, new_weights: dict, update_type: str, name: str) -> dict:
     logging.debug(f'Applying {new_weights}')
     cleaned_weights = {}
@@ -362,7 +356,7 @@ def roll_linked_options(weights: dict) -> dict:
         if "name" not in option_set:
             raise ValueError("One of your linked options does not have a name.")
         try:
-            if roll_percentage(option_set["percentage"]):
+            if Options.roll_percentage(option_set["percentage"]):
                 logging.debug(f"Linked option {option_set['name']} triggered.")
                 new_options = option_set["options"]
                 for category_name, category_options in new_options.items():
@@ -395,7 +389,7 @@ def roll_triggers(weights: dict, triggers: list, valid_keys: set) -> dict:
             trigger_result = get_choice("option_result", option_set)
             result = get_choice(key, currently_targeted_weights)
             currently_targeted_weights[key] = result
-            if result == trigger_result and roll_percentage(get_choice("percentage", option_set, 100)):
+            if result == trigger_result and Options.roll_percentage(get_choice("percentage", option_set, 100)):
                 for category_name, category_options in option_set["options"].items():
                     currently_targeted_weights = weights
                     if category_name:

--- a/Options.py
+++ b/Options.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 from schema import And, Optional, Or, Schema
 from typing_extensions import Self
 
+from Generate import roll_percentage
 from Utils import get_fuzzy_results, is_iterable_except_str, output_path
 
 if typing.TYPE_CHECKING:
@@ -971,7 +972,7 @@ class PlandoTexts(Option[typing.List[PlandoText]], VerifyKeys):
         if isinstance(data, typing.Iterable):
             for text in data:
                 if isinstance(text, typing.Mapping):
-                    if random.random() < float(text.get("percentage", 100)/100):
+                    if roll_percentage(text.get("percentage", 100)):
                         at = text.get("at", None)
                         if at is not None:
                             if isinstance(at, dict):
@@ -997,7 +998,7 @@ class PlandoTexts(Option[typing.List[PlandoText]], VerifyKeys):
                         else:
                             raise OptionError("\"at\" must be a valid string or weighted list of strings!")
                 elif isinstance(text, PlandoText):
-                    if random.random() < float(text.percentage/100):
+                    if roll_percentage(text.percentage):
                         texts.append(text)
                 else:
                     raise Exception(f"Cannot create plando text from non-dictionary type, got {type(text)}")
@@ -1121,7 +1122,7 @@ class PlandoConnections(Option[typing.List[PlandoConnection]], metaclass=Connect
         for connection in data:
             if isinstance(connection, typing.Mapping):
                 percentage = connection.get("percentage", 100)
-                if random.random() < float(percentage / 100):
+                if roll_percentage(percentage):
                     entrance = connection.get("entrance", None)
                     if is_iterable_except_str(entrance):
                         entrance = random.choice(sorted(entrance))
@@ -1139,7 +1140,7 @@ class PlandoConnections(Option[typing.List[PlandoConnection]], metaclass=Connect
                         percentage
                     ))
             elif isinstance(connection, PlandoConnection):
-                if random.random() < float(connection.percentage / 100):
+                if roll_percentage(connection.percentage):
                     value.append(connection)
             else:
                 raise Exception(f"Cannot create connection from non-Dict type, got {type(connection)}.")
@@ -1411,7 +1412,7 @@ class ItemLinks(OptionList):
 
 class PlandoItem(typing.NamedTuple):
     items: typing.Union[typing.List[str], typing.Dict[str, typing.Any]]
-    locations: typing.Optional[typing.List[str]]
+    locations: typing.List[str] = []
     world: typing.Union[int, str, bool, None, typing.Iterable[str], typing.Set[int]] = False
     from_pool: bool = True
     force: typing.Union[bool, typing.Literal["silent"]] = "silent"
@@ -1437,18 +1438,21 @@ class PlandoItems(Option[typing.List[PlandoItem]]):
         value: typing.List[PlandoItem] = []
         for item in data:
             if isinstance(item, typing.Mapping):
+                if not isinstance(item.get("percentage", 100), int):
+                    percentage_type = type(item["percentage"])
+                    raise Exception(f"Plando `percentage` has to be int, not {percentage_type}.")
                 percentage = item.get("percentage", 100)
-                if random.random() < float(percentage / 100):
+                if roll_percentage(percentage):
                     count = item.get("count", False)
                     items = item.get("items", [])
                     if not items:
-                        items = item.get("item", None)  # explcitly throw an error here if not present
+                        items = item.get("item", None)  # explicitly throw an error here if not present
                         if not items:
                             raise Exception("You must specify at least one item to place items with plando.")
                         items = [items]
-                    locations = item.get("locations", [])
+                    locations = item["locations"]
                     if not locations:
-                        locations = item.get("location", None)
+                        locations = item.get("location", [])
                         if locations:
                             locations = [locations]
                     world = item.get("world", False)
@@ -1456,7 +1460,7 @@ class PlandoItems(Option[typing.List[PlandoItem]]):
                     force = item.get("force", "silent")
                     value.append(PlandoItem(items, locations, world, from_pool, force, count, percentage))
             elif isinstance(item, PlandoItem):
-                if random.random() < float(item.percentage / 100):
+                if roll_percentage(item.percentage):
                     value.append(item)
             else:
                 raise Exception(f"Cannot create plando item from non-Dict type, got {type(item)}.")

--- a/Options.py
+++ b/Options.py
@@ -1418,7 +1418,7 @@ class ItemLinks(OptionList):
 
 class PlandoItem(typing.NamedTuple):
     items: typing.Union[typing.List[str], typing.Dict[str, typing.Any]]
-    locations: typing.List[str] = []
+    locations: typing.List[str]
     world: typing.Union[int, str, bool, None, typing.Iterable[str], typing.Set[int]] = False
     from_pool: bool = True
     force: typing.Union[bool, typing.Literal["silent"]] = "silent"
@@ -1456,7 +1456,7 @@ class PlandoItems(Option[typing.List[PlandoItem]]):
                         if not items:
                             raise Exception("You must specify at least one item to place items with plando.")
                         items = [items]
-                    locations = item["locations"]
+                    locations = item.get("locations", [])
                     if not locations:
                         locations = item.get("location", [])
                         if locations:

--- a/Options.py
+++ b/Options.py
@@ -1444,10 +1444,10 @@ class PlandoItems(Option[typing.List[PlandoItem]]):
         value: typing.List[PlandoItem] = []
         for item in data:
             if isinstance(item, typing.Mapping):
-                if not isinstance(item.get("percentage", 100), int):
-                    percentage_type = type(item["percentage"])
-                    raise Exception(f"Plando `percentage` has to be int, not {percentage_type}.")
                 percentage = item.get("percentage", 100)
+                if not isinstance(percentage, int):
+                    percentage_type = type(percentage)
+                    raise Exception(f"Plando `percentage` has to be int, not {percentage_type}.")
                 if roll_percentage(percentage):
                     count = item.get("count", False)
                     items = item.get("items", [])

--- a/Options.py
+++ b/Options.py
@@ -15,7 +15,6 @@ from dataclasses import dataclass
 from schema import And, Optional, Or, Schema
 from typing_extensions import Self
 
-from Generate import roll_percentage
 from Utils import get_fuzzy_results, is_iterable_except_str, output_path
 
 if typing.TYPE_CHECKING:
@@ -23,6 +22,11 @@ if typing.TYPE_CHECKING:
     from worlds.AutoWorld import World
     import pathlib
 
+def roll_percentage(percentage: typing.Union[int, float]) -> bool:
+    """Roll a percentage chance.
+    percentage is expected to be in range [0, 100]"""
+    # Copied from Generate.py
+    return random.random() < (float(percentage) / 100)
 
 class OptionError(ValueError):
     pass

--- a/Options.py
+++ b/Options.py
@@ -26,7 +26,6 @@ if typing.TYPE_CHECKING:
 def roll_percentage(percentage: typing.Union[int, float]) -> bool:
     """Roll a percentage chance.
     percentage is expected to be in range [0, 100]"""
-    # Copied from Generate.py
     return random.random() < (float(percentage) / 100)
 
 
@@ -1446,8 +1445,7 @@ class PlandoItems(Option[typing.List[PlandoItem]]):
             if isinstance(item, typing.Mapping):
                 percentage = item.get("percentage", 100)
                 if not isinstance(percentage, int):
-                    percentage_type = type(percentage)
-                    raise Exception(f"Plando `percentage` has to be int, not {percentage_type}.")
+                    raise Exception(f"Plando `percentage` has to be int, not {type(percentage)}.")
                 if roll_percentage(percentage):
                     count = item.get("count", False)
                     items = item.get("items", [])

--- a/Options.py
+++ b/Options.py
@@ -22,11 +22,13 @@ if typing.TYPE_CHECKING:
     from worlds.AutoWorld import World
     import pathlib
 
+
 def roll_percentage(percentage: typing.Union[int, float]) -> bool:
     """Roll a percentage chance.
     percentage is expected to be in range [0, 100]"""
     # Copied from Generate.py
     return random.random() < (float(percentage) / 100)
+
 
 class OptionError(ValueError):
     pass

--- a/test/general/test_implemented.py
+++ b/test/general/test_implemented.py
@@ -1,8 +1,7 @@
 import unittest
 
-from Fill import distribute_items_restrictive, distribute_planned
+from Fill import distribute_items_restrictive
 from NetUtils import encode
-from Options import PlandoItem
 from worlds.AutoWorld import AutoWorldRegister, call_all
 from worlds import failed_world_loads
 from . import setup_solo_multiworld


### PR DESCRIPTION
## What is this fixing or adding?
All comments except for https://github.com/ArchipelagoMW/Archipelago/pull/3046#discussion_r1795646661 ~~and https://github.com/ArchipelagoMW/Archipelago/pull/3046#discussion_r1807821124~~

In particular, cleaning up unused imports, using `roll_percentage` (copied from `Generate.py`), making `locations` non-Optional (you were iterating over it, it was never `None`), checking the typing for `force`, `percentage`, and `locations`, changing `force` to only allow for the typing that was provided (boolean and "silent"), changing `locations` to only allow for a list as the dictionary was functionality was removed (it was misleading beforehand anyway), and rearranging the way location groups were checked for so that there couldn't be any spiraling of any kind.

## How was this tested?

Probably not enough. Some test generations with some plando configurations to hit the new exceptions and unit tests. But not much else.