### PR TITLE
Suggestions from review

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -1455,20 +1455,19 @@ class PlandoItems(Option[typing.List[PlandoItem]]):
                         items = item.get("item", None)  # explicitly throw an error here if not present
                         if not items:
                             raise Exception("You must specify at least one item to place items with plando.")
+                        count = 1
                         if isinstance(items, str):
                             items = [items]
-                        elif isinstance(items, dict):
-                            count = 1
-                        else:
+                        elif not isinstance(items, dict):
                             raise Exception(f"Plando 'item' has to be string or dictionary, not {type(items)}.")
                     locations = item.get("locations", [])
                     if not locations:
                         locations = item.get("location", [])
+                        if locations:
+                            count = 1
                         if isinstance(locations, str):
                             locations = [locations]
-                        if isinstance(locations, list) and locations:
-                            count = 1
-                        elif not isinstance(locations, list):
+                        if not isinstance(locations, list):
                             raise Exception(f"Plando `location` has to be string or list, not {type(locations)}")
                     world = item.get("world", False)
                     from_pool = item.get("from_pool", True)


### PR DESCRIPTION
## What is this fixing or adding?

* Raises an exception if `percentage` is outside the [0, 100] range
* Raises an exception if a `item`/`items` *dictionary* contains both an item and a group that contains it
* Restores the ability for `item` to be a dictionary
* Enforces the string/list typing of `location`/`locations`
* Brings back `count = 1` when using `item` or `location`

## How was this tested?

Generating with yamls and unit tests.